### PR TITLE
fix: GitHub Pagesデプロイの修正（pnpmバージョン + 書き込み権限）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,7 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
-        with:
-          version: 9
+        # package.jsonのpackageManagerフィールドからバージョンを自動取得
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # gh-pagesブランチへの書き込み権限を付与
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## 概要

GitHub Pagesへのデプロイが失敗する2つの問題を修正します。

## 修正内容

### 1. pnpmバージョンの不一致を解決

**問題:**
- GitHub Actionsでpnpm v9を使用していたが、package.jsonではv10.4.1を指定
- pnpmのバージョン不一致により、patchedDependenciesのエラーが発生

**修正:**
```yaml
- name: Setup pnpm
  uses: pnpm/action-setup@v2
  # package.jsonのpackageManagerフィールドから自動取得